### PR TITLE
Add Black Orc, Chaos Chosen and Chaos Dwarf teams

### DIFF
--- a/Amazon.cat
+++ b/Amazon.cat
@@ -235,4 +235,23 @@
       </constraints>
     </categoryEntry>
   </categoryEntries>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Team League" hidden="false" id="f872-6f57-c9ad-ed10">
+      <entryLinks>
+        <entryLink import="true" name="Lustrian Superleague" hidden="false" id="fc8d-6da7-70fe-274c" type="selectionEntry" targetId="9e52-21d6-b650-0f2e">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4428-3f58-bef8-b527-min" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4428-3f58-bef8-b527-max" includeChildSelections="false"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <categoryLinks>
+        <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="73fa-0765-26a5-86b1" primary="true" name="Team Management"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="84a6-1574-be62-abc5-min" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="84a6-1574-be62-abc5-max" includeChildSelections="true"/>
+      </constraints>
+    </selectionEntry>
+  </selectionEntries>
 </catalogue>

--- a/Black Orc.cat
+++ b/Black Orc.cat
@@ -191,5 +191,22 @@
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="86b8-64b2-8273-bd96-max" includeChildSelections="true"/>
       </constraints>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Team League" hidden="false" id="d7f4-ed40-5258-4986">
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="a8a9-f7bb-ff69-f3fa-min" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="a8a9-f7bb-ff69-f3fa-max" includeChildSelections="true"/>
+      </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Badlands Brawl" hidden="false" id="122d-b3c8-31d2-6227" type="selectionEntry" targetId="1eb9-891a-5a20-b694">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5e7a-af8f-bb52-c751-min" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5e7a-af8f-bb52-c751-max" includeChildSelections="false"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <categoryLinks>
+        <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="fff9-252c-dc88-a18a" primary="true" name="Team Management"/>
+      </categoryLinks>
+    </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Bretonnian.cat
+++ b/Bretonnian.cat
@@ -227,4 +227,23 @@
       </costs>
     </entryLink>
   </entryLinks>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Team League" hidden="false" id="56b1-47d2-bfe0-8ded">
+      <categoryLinks>
+        <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="6fff-3bf2-e94f-bd7b" primary="true" name="Team Management"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="7893-8b51-9d61-79c8-min" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7893-8b51-9d61-79c8-max" includeChildSelections="true"/>
+      </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Old World Classic" hidden="false" id="ba75-29c0-9bdc-2b3d" type="selectionEntry" targetId="3d18-00d7-c09b-d261">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="26cd-fd77-ede2-ac18-min" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26cd-fd77-ede2-ac18-max" includeChildSelections="false"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
 </catalogue>

--- a/Chaos Chosen.cat
+++ b/Chaos Chosen.cat
@@ -116,7 +116,7 @@
       </profiles>
       <infoLinks>
         <infoLink name="Always Hungry* (Active)" id="fa53-cde5-6fd3-5ce9" hidden="false" type="rule" targetId="e071-25e9-5e97-ad86"/>
-        <infoLink name="Loner (4+)* (Passive)" id="bcb7-e2a4-6e9d-3035" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
+        <infoLink name="Loner (X+)* (Passive)" id="bcb7-e2a4-6e9d-3035" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
         <infoLink name="Mighty Blow (Active)" id="b70e-9855-64f2-540f" hidden="false" type="rule" targetId="14aa-a202-4417-3e92"/>
         <infoLink name="Projectile Vomit (Active)" id="7dd1-0efc-43d3-c31b" hidden="false" type="rule" targetId="e7c5-e289-f998-ab71"/>
         <infoLink name="Really Stupid (Passive)" id="a2e6-9981-87fb-ea4c" hidden="false" type="rule" targetId="07b6-8266-b73c-6a9f"/>
@@ -179,7 +179,7 @@
         </entryLink>
       </entryLinks>
       <infoLinks>
-        <infoLink name="Loner (4+)* (Passive)" id="0491-7e8c-e413-9f72" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
+        <infoLink name="Loner (X+)* (Passive)" id="0491-7e8c-e413-9f72" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
         <infoLink name="Throw Team-mate (Active)" id="43d7-e5e1-68fa-a124" hidden="false" type="rule" targetId="25e0-225c-008f-bda3"/>
         <infoLink name="Thick Skull (Passive)" id="16c2-c356-ee90-a700" hidden="false" type="rule" targetId="d547-b26d-592c-30e1"/>
         <infoLink name="Bone Head* (Passive)" id="fd6c-2cb2-ec53-8002" hidden="false" type="rule" targetId="6e98-03d2-86a2-66e2"/>
@@ -213,12 +213,12 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Loner (4+)* (Passive)" id="2b47-8eee-b03d-c8e2" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
+        <infoLink name="Loner (X+)* (Passive)" id="2b47-8eee-b03d-c8e2" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
         <infoLink name="Frenzy* (Active)" id="840c-cfe9-5b2c-63fe" hidden="false" type="rule" targetId="23bd-8f90-1641-a278"/>
         <infoLink name="Horns (Active)" id="1220-9f77-0be1-a095" hidden="false" type="rule" targetId="6470-3281-c861-bbae"/>
         <infoLink name="Mighty Blow (Active)" id="b8f2-1b11-63b8-7bca" hidden="false" type="rule" targetId="14aa-a202-4417-3e92"/>
         <infoLink name="Thick Skull (Passive)" id="ec42-af35-8199-00cf" hidden="false" type="rule" targetId="d547-b26d-592c-30e1"/>
-        <infoLink name="Unchanneled Fury* (Active)" id="c136-9b64-e52d-3842" hidden="false" type="rule" targetId="454e-a6ad-7d72-438f"/>
+        <infoLink name="Unchannelled Fury* (Active)" id="c136-9b64-e52d-3842" hidden="false" type="rule" targetId="454e-a6ad-7d72-438f"/>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Primary Skill" hidden="false" id="0d0e-c075-bc5e-fdcf" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
@@ -264,13 +264,18 @@
       <categoryLinks>
         <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="e1cc-4674-1993-1839" primary="true" name="Team Management"/>
       </categoryLinks>
-      <infoLinks>
-        <infoLink name="Favoured of (choose any)" id="1588-fb7b-e4c3-c9c3" hidden="false" type="rule" targetId="84ac-f521-708b-c779"/>
-      </infoLinks>
       <constraints>
-        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="1fa7-7da4-08b3-0d2c-min" includeChildSelections="true"/>
-        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="1fa7-7da4-08b3-0d2c-max" includeChildSelections="true"/>
+        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="9d80-e4bd-dd0e-6b22-min" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="9d80-e4bd-dd0e-6b22-max" includeChildSelections="true"/>
       </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Favored of ..." hidden="false" id="c878-1893-3936-3aaa" type="selectionEntry" targetId="7614-610c-c42c-5a78">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7525-f1fe-8a2e-1b1e-min" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7525-f1fe-8a2e-1b1e-max" includeChildSelections="false"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Chaos Alignment" hidden="false" id="c5ec-93a8-ff55-a908">
       <entryLinks>
@@ -280,8 +285,8 @@
         <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="0418-cb7b-db90-3b81" primary="true" name="Team Management"/>
       </categoryLinks>
       <constraints>
-        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="d120-b38b-a3fe-9334-min" includeChildSelections="true"/>
-        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="d120-b38b-a3fe-9334-max" includeChildSelections="true"/>
+        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="7e23-ce58-eaea-10c3-min" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7e23-ce58-eaea-10c3-max" includeChildSelections="true"/>
       </constraints>
     </selectionEntry>
   </selectionEntries>

--- a/Chaos Dwarf.cat
+++ b/Chaos Dwarf.cat
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue library="false" id="02f0-ac7b-8698-0f4c" name="Chaos Dwarf" gameSystemId="sys-783d-8aac-9dfc-917b" gameSystemRevision="1" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <sharedSelectionEntries>
+    <selectionEntry type="model" import="true" name="Flamesmith" hidden="false" id="082a-05c9-f837-ca5d">
+      <profiles>
+        <profile name="Flamesmith" typeId="8471-fde9-4157-5b28" typeName="Player" hidden="false" id="c0bd-52af-e064-cf97">
+          <characteristics>
+            <characteristic name="MA" typeId="5b6f-6247-0c21-83d3">5</characteristic>
+            <characteristic name="ST" typeId="6fbf-0646-8c8f-4851">3</characteristic>
+            <characteristic name="AG" typeId="644d-fe29-947f-5eb7">4+</characteristic>
+            <characteristic name="PA" typeId="51bf-7f91-4729-9e2d">6+</characteristic>
+            <characteristic name="AV" typeId="599c-91d6-b1ed-6aba">10+</characteristic>
+            <characteristic name="Skills &amp; Traits" typeId="a256-4228-5691-a7d4">Brawler, Breathe Fire, Disturbing Presence, Thick Skull</characteristic>
+            <characteristic name="Primary" typeId="45d5-7c88-6f4f-75fb">GS</characteristic>
+            <characteristic name="Secondary" typeId="fb9c-ee87-c6b3-9f1d">ADM</characteristic>
+            <characteristic name="Cost" typeId="7b1e-4ff6-3a59-6f21">80,000</characteristic>
+            <characteristic name="SPP" typeId="57d9-dc9e-5331-d2af">0</characteristic>
+            <characteristic name="Keywords" typeId="ac0d-44e2-a884-6d6a">**Dwarf**, **Special**</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="69f8-eb37-db8c-47de" id="eccd-d6d7-6c89-4aee" primary="true" name="Player"/>
+        <categoryLink targetId="0e28-f117-7a31-5e27" id="1c7d-c161-09ca-c206" primary="false" name="Flamesmith"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Brawler (Active)" id="321c-978a-5792-eef9" hidden="false" type="rule" targetId="d839-ffbd-92cc-0ec0"/>
+        <infoLink name="Breathe Fire (Active)" id="fed5-7cd5-9a6e-a0fd" hidden="false" type="rule" targetId="0ee0-932b-f823-c39b"/>
+        <infoLink name="Disturbing Presence* (Active)" id="4833-9e0b-1122-ce02" hidden="false" type="rule" targetId="7c10-67d5-0349-a4b8"/>
+        <infoLink name="Thick Skull (Passive)" id="353d-194f-a7a8-6d79" hidden="false" type="rule" targetId="d547-b26d-592c-30e1"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Primary Skill" hidden="false" id="d67f-d6a1-cc36-3e4d" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
+          <entryLinks>
+            <entryLink import="true" name="General" hidden="false" id="50ec-5b1a-d8e6-7a53" type="selectionEntryGroup" targetId="f7fd-b955-21d7-90d4"/>
+            <entryLink import="true" name="Strength" hidden="false" id="5c65-de85-6a37-dbb5" type="selectionEntryGroup" targetId="31a8-34bd-4d79-5269"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="Secondary Skill" hidden="false" id="5341-c249-8d8e-bee2" type="selectionEntryGroup" targetId="290c-cda9-c02e-31a1">
+          <entryLinks>
+            <entryLink import="true" name="Devious" hidden="false" id="46dd-e4b9-7211-87ba" type="selectionEntryGroup" targetId="d38f-5d99-694f-98b4"/>
+            <entryLink import="true" name="Mutation" hidden="false" id="52e6-b90c-429f-03d5" type="selectionEntryGroup" targetId="cc5f-a16a-3abc-1266"/>
+            <entryLink import="true" name="Agility" hidden="false" id="ad34-c72c-173a-19ee" type="selectionEntryGroup" targetId="fcc9-3efe-db4e-206d"/>
+          </entryLinks>
+        </entryLink>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.3d15-f50c-c6e3-17e9"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.9256-339d-7987-49c4"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.6f4e-09ba-73c2-9fcc"/>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Chaos Dwarf Blocker" hidden="false" id="9ac2-cc89-d21f-b1f2">
+      <profiles>
+        <profile name="Chaos Dwarf Blocker" typeId="8471-fde9-4157-5b28" typeName="Player" hidden="false" id="0818-d4a6-fbba-621b">
+          <characteristics>
+            <characteristic name="MA" typeId="5b6f-6247-0c21-83d3">4</characteristic>
+            <characteristic name="ST" typeId="6fbf-0646-8c8f-4851">3</characteristic>
+            <characteristic name="AG" typeId="644d-fe29-947f-5eb7">4+</characteristic>
+            <characteristic name="PA" typeId="51bf-7f91-4729-9e2d">6+</characteristic>
+            <characteristic name="AV" typeId="599c-91d6-b1ed-6aba">10+</characteristic>
+            <characteristic name="Skills &amp; Traits" typeId="a256-4228-5691-a7d4">Block, Iron Hard Skin, Thick Skull</characteristic>
+            <characteristic name="Primary" typeId="45d5-7c88-6f4f-75fb">GS</characteristic>
+            <characteristic name="Secondary" typeId="fb9c-ee87-c6b3-9f1d">ADM</characteristic>
+            <characteristic name="Cost" typeId="7b1e-4ff6-3a59-6f21">70,000</characteristic>
+            <characteristic name="SPP" typeId="57d9-dc9e-5331-d2af">0</characteristic>
+            <characteristic name="Keywords" typeId="ac0d-44e2-a884-6d6a">**Blocker**, **Dwarf**</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Block (Active)" id="bc7b-e519-608f-6219" hidden="false" type="rule" targetId="85b4-cdee-1e19-3038"/>
+        <infoLink name="Iron Hard Skin (Passive)" id="2b4d-fabf-c4fb-2c9e" hidden="false" type="rule" targetId="cd02-03fb-ff2b-a74a"/>
+        <infoLink name="Thick Skull (Passive)" id="355f-8ec5-4089-adb9" hidden="false" type="rule" targetId="d547-b26d-592c-30e1"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Primary Skill" hidden="false" id="a887-b9b5-1df1-cfd3" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
+          <entryLinks>
+            <entryLink import="true" name="General" hidden="false" id="5442-85d7-74c3-19c5" type="selectionEntryGroup" targetId="f7fd-b955-21d7-90d4"/>
+            <entryLink import="true" name="Strength" hidden="false" id="b2a5-dcec-6bd5-af3f" type="selectionEntryGroup" targetId="31a8-34bd-4d79-5269"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="Secondary Skill" hidden="false" id="956f-8720-fc2e-a057" type="selectionEntryGroup" targetId="290c-cda9-c02e-31a1">
+          <entryLinks>
+            <entryLink import="true" name="Agility" hidden="false" id="b831-cf46-cce7-fdf5" type="selectionEntryGroup" targetId="fcc9-3efe-db4e-206d"/>
+            <entryLink import="true" name="Mutation" hidden="false" id="b08c-e27f-d05e-addb" type="selectionEntryGroup" targetId="cc5f-a16a-3abc-1266"/>
+            <entryLink import="true" name="Devious" hidden="false" id="9d40-a6cd-5dc5-ff2d" type="selectionEntryGroup" targetId="d38f-5d99-694f-98b4"/>
+          </entryLinks>
+        </entryLink>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.0e89-4745-7902-b155"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.3d15-f50c-c6e3-17e9"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.1f07-b511-b363-615b"/>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="69f8-eb37-db8c-47de" id="3500-ff2d-7e7d-26e0" primary="true" name="Player"/>
+        <categoryLink targetId="3ba4-e9d0-1bac-92f7" id="1c38-5690-172e-6a12" primary="false" name="Chaos Dwarf Blocker"/>
+      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Hobgoblin Lineman" hidden="false" id="1b41-182d-9b3c-a0b0">
+      <profiles>
+        <profile name="Hobgoblin Lineman" typeId="8471-fde9-4157-5b28" typeName="Player" hidden="false" id="a84c-ae81-4b46-68d0">
+          <characteristics>
+            <characteristic name="MA" typeId="5b6f-6247-0c21-83d3">6</characteristic>
+            <characteristic name="ST" typeId="6fbf-0646-8c8f-4851">3</characteristic>
+            <characteristic name="AG" typeId="644d-fe29-947f-5eb7">3+</characteristic>
+            <characteristic name="PA" typeId="51bf-7f91-4729-9e2d">4+</characteristic>
+            <characteristic name="AV" typeId="599c-91d6-b1ed-6aba">8+</characteristic>
+            <characteristic name="Skills &amp; Traits" typeId="a256-4228-5691-a7d4"/>
+            <characteristic name="Primary" typeId="45d5-7c88-6f4f-75fb">D</characteristic>
+            <characteristic name="Secondary" typeId="fb9c-ee87-c6b3-9f1d">AGS</characteristic>
+            <characteristic name="Cost" typeId="7b1e-4ff6-3a59-6f21">40,000</characteristic>
+            <characteristic name="SPP" typeId="57d9-dc9e-5331-d2af">0</characteristic>
+            <characteristic name="Keywords" typeId="ac0d-44e2-a884-6d6a">**Goblin**, **Lineman**</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="69f8-eb37-db8c-47de" id="d2e7-1fb0-559a-2302" primary="true" name="Player"/>
+        <categoryLink targetId="553b-6d18-8ac0-77cd" id="7785-e291-a298-712f" primary="false" name="Hobgoblin Lineman"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Primary Skill" hidden="false" id="f106-7b62-bef2-301f" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
+          <entryLinks>
+            <entryLink import="true" name="Devious" hidden="false" id="41c1-11c4-6707-1fec" type="selectionEntryGroup" targetId="d38f-5d99-694f-98b4"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="Secondary Skill" hidden="false" id="46dc-867e-37aa-85eb" type="selectionEntryGroup" targetId="290c-cda9-c02e-31a1">
+          <entryLinks>
+            <entryLink import="true" name="Agility" hidden="false" id="9e28-3982-8e7d-8420" type="selectionEntryGroup" targetId="fcc9-3efe-db4e-206d"/>
+            <entryLink import="true" name="Strength" hidden="false" id="155c-08d1-e408-c1f3" type="selectionEntryGroup" targetId="31a8-34bd-4d79-5269"/>
+            <entryLink import="true" name="General" hidden="false" id="6bf1-dadd-1249-9d88" type="selectionEntryGroup" targetId="f7fd-b955-21d7-90d4"/>
+          </entryLinks>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Minotaur" hidden="false" id="e104-28ff-6f3d-77c8">
+      <profiles>
+        <profile name="Minotaur" typeId="8471-fde9-4157-5b28" typeName="Player" hidden="false" id="9d43-ebdf-7454-1293">
+          <characteristics>
+            <characteristic name="MA" typeId="5b6f-6247-0c21-83d3">5</characteristic>
+            <characteristic name="ST" typeId="6fbf-0646-8c8f-4851">5</characteristic>
+            <characteristic name="AG" typeId="644d-fe29-947f-5eb7">4+</characteristic>
+            <characteristic name="PA" typeId="51bf-7f91-4729-9e2d">6+</characteristic>
+            <characteristic name="AV" typeId="599c-91d6-b1ed-6aba">9+</characteristic>
+            <characteristic name="Skills &amp; Traits" typeId="a256-4228-5691-a7d4">Frenzy, Horns, Loner (4+), Mighty Blow, Thick Skull, Unchannelled Fury</characteristic>
+            <characteristic name="Primary" typeId="45d5-7c88-6f4f-75fb">MS</characteristic>
+            <characteristic name="Secondary" typeId="fb9c-ee87-c6b3-9f1d">AG</characteristic>
+            <characteristic name="Cost" typeId="7b1e-4ff6-3a59-6f21">150,000</characteristic>
+            <characteristic name="SPP" typeId="57d9-dc9e-5331-d2af">0</characteristic>
+            <characteristic name="Keywords" typeId="ac0d-44e2-a884-6d6a">**Big Guy**, **Minotaur**</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="69f8-eb37-db8c-47de" id="36c9-0e16-1611-a7d1" primary="true" name="Player"/>
+        <categoryLink targetId="3d3b-777b-8c7d-a187" id="7d75-056c-590a-717a" primary="false" name="Minotaur"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Frenzy* (Active)" id="e316-ad7e-052c-d308" hidden="false" type="rule" targetId="23bd-8f90-1641-a278"/>
+        <infoLink name="Horns (Active)" id="d155-374f-0619-6281" hidden="false" type="rule" targetId="6470-3281-c861-bbae"/>
+        <infoLink name="Loner (X+)* (Passive)" id="1899-f66d-fb13-09e5" hidden="false" type="rule" targetId="5ca2-1ec1-85bb-e3b5"/>
+        <infoLink name="Mighty Blow (Active)" id="ad72-20bc-312b-25b3" hidden="false" type="rule" targetId="14aa-a202-4417-3e92"/>
+        <infoLink name="Thick Skull (Passive)" id="a42e-da09-0b43-7395" hidden="false" type="rule" targetId="d547-b26d-592c-30e1"/>
+        <infoLink name="Unchannelled Fury* (Active)" id="2a1c-43b9-3eb2-fedd" hidden="false" type="rule" targetId="454e-a6ad-7d72-438f"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Primary Skill" hidden="false" id="ca82-10b5-4baf-040d" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
+          <entryLinks>
+            <entryLink import="true" name="Mutation" hidden="false" id="ae06-d2d3-bc95-1958" type="selectionEntryGroup" targetId="cc5f-a16a-3abc-1266"/>
+            <entryLink import="true" name="Strength" hidden="false" id="c9f1-d3af-b185-7b0c" type="selectionEntryGroup" targetId="31a8-34bd-4d79-5269"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="Secondary Skill" hidden="false" id="c5b2-5ed6-b212-b97f" type="selectionEntryGroup" targetId="290c-cda9-c02e-31a1">
+          <entryLinks>
+            <entryLink import="true" name="Agility" hidden="false" id="df6c-9e7c-a2bb-8884" type="selectionEntryGroup" targetId="fcc9-3efe-db4e-206d"/>
+            <entryLink import="true" name="General" hidden="false" id="36a3-d5ac-8bbf-1d9b" type="selectionEntryGroup" targetId="f7fd-b955-21d7-90d4"/>
+          </entryLinks>
+        </entryLink>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.174f-5c4a-d02f-096e"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.b392-9974-2af9-bcf0"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.b7af-e07f-efc9-8aa4"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.3d15-f50c-c6e3-17e9"/>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Sneaky Stabba" hidden="false" id="0d88-2f7d-b8d9-9507">
+      <profiles>
+        <profile name="Sneaky Stabba" typeId="8471-fde9-4157-5b28" typeName="Player" hidden="false" id="0a96-6ef8-1b41-860b">
+          <characteristics>
+            <characteristic name="MA" typeId="5b6f-6247-0c21-83d3">6</characteristic>
+            <characteristic name="ST" typeId="6fbf-0646-8c8f-4851">3</characteristic>
+            <characteristic name="AG" typeId="644d-fe29-947f-5eb7">3+</characteristic>
+            <characteristic name="PA" typeId="51bf-7f91-4729-9e2d">5+</characteristic>
+            <characteristic name="AV" typeId="599c-91d6-b1ed-6aba">8+</characteristic>
+            <characteristic name="Skills &amp; Traits" typeId="a256-4228-5691-a7d4">Shadowing, Stab</characteristic>
+            <characteristic name="Primary" typeId="45d5-7c88-6f4f-75fb">DG</characteristic>
+            <characteristic name="Secondary" typeId="fb9c-ee87-c6b3-9f1d">AS</characteristic>
+            <characteristic name="Cost" typeId="7b1e-4ff6-3a59-6f21">60,000</characteristic>
+            <characteristic name="SPP" typeId="57d9-dc9e-5331-d2af">0</characteristic>
+            <characteristic name="Keywords" typeId="ac0d-44e2-a884-6d6a">**Goblin**, **Special**</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink targetId="69f8-eb37-db8c-47de" id="30cb-9bf8-ce02-c608" primary="true" name="Player"/>
+        <categoryLink targetId="0969-47b5-9a25-9322" id="d310-8f6a-2424-fa33" primary="false" name="Sneaky Stabba"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Shadowing (Active)" id="b925-3c9a-9ec5-6d44" hidden="false" type="rule" targetId="5263-3b6c-910f-3a9d"/>
+        <infoLink name="Stab (Active)" id="6565-d8fa-014a-727d" hidden="false" type="rule" targetId="26c3-7c06-95b0-973b"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Primary Skill" hidden="false" id="d9be-ad88-b9db-8fe9" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
+          <entryLinks>
+            <entryLink import="true" name="Devious" hidden="false" id="0f80-0ff1-e208-78b5" type="selectionEntryGroup" targetId="d38f-5d99-694f-98b4"/>
+            <entryLink import="true" name="General" hidden="false" id="2a08-2504-b985-3c08" type="selectionEntryGroup" targetId="f7fd-b955-21d7-90d4"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="Secondary Skill" hidden="false" id="94e3-1f06-7213-6f1e" type="selectionEntryGroup" targetId="290c-cda9-c02e-31a1">
+          <entryLinks>
+            <entryLink import="true" name="Agility" hidden="false" id="b3fb-e1ce-7399-7a08" type="selectionEntryGroup" targetId="fcc9-3efe-db4e-206d"/>
+            <entryLink import="true" name="Strength" hidden="false" id="9fe1-d8d4-41c1-2f84" type="selectionEntryGroup" targetId="31a8-34bd-4d79-5269"/>
+          </entryLinks>
+        </entryLink>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.9218-8f39-e528-6b51"/>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Bull Centaur" hidden="false" id="4d10-f149-c8b7-9b21">
+      <profiles>
+        <profile name="Bull Centaur" typeId="8471-fde9-4157-5b28" typeName="Player" hidden="false" id="4348-fbf7-9195-4682">
+          <characteristics>
+            <characteristic name="MA" typeId="5b6f-6247-0c21-83d3">6</characteristic>
+            <characteristic name="ST" typeId="6fbf-0646-8c8f-4851">4</characteristic>
+            <characteristic name="AG" typeId="644d-fe29-947f-5eb7">4+</characteristic>
+            <characteristic name="PA" typeId="51bf-7f91-4729-9e2d">6+</characteristic>
+            <characteristic name="AV" typeId="599c-91d6-b1ed-6aba">10+</characteristic>
+            <characteristic name="Skills &amp; Traits" typeId="a256-4228-5691-a7d4">Sprint, Sure Feet, Thick Skull, Unsteady</characteristic>
+            <characteristic name="Primary" typeId="45d5-7c88-6f4f-75fb">GS</characteristic>
+            <characteristic name="Secondary" typeId="fb9c-ee87-c6b3-9f1d">ADM</characteristic>
+            <characteristic name="Cost" typeId="7b1e-4ff6-3a59-6f21">130,000</characteristic>
+            <characteristic name="SPP" typeId="57d9-dc9e-5331-d2af">0</characteristic>
+            <characteristic name="Keywords" typeId="ac0d-44e2-a884-6d6a">**Blitzer**, **Dwarf**</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <entryLinks>
+        <entryLink import="true" name="Primary Skill" hidden="false" id="15c3-b49c-29b7-9b98" type="selectionEntryGroup" targetId="f398-0d58-6146-99f7">
+          <entryLinks>
+            <entryLink import="true" name="General" hidden="false" id="bb6b-625a-f955-1897" type="selectionEntryGroup" targetId="f7fd-b955-21d7-90d4"/>
+            <entryLink import="true" name="Strength" hidden="false" id="a937-8a06-55e8-9342" type="selectionEntryGroup" targetId="31a8-34bd-4d79-5269"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="Secondary Skill" hidden="false" id="51fc-985e-a161-a9b1" type="selectionEntryGroup" targetId="290c-cda9-c02e-31a1">
+          <entryLinks>
+            <entryLink import="true" name="Agility" hidden="false" id="ee85-8c21-97b9-666e" type="selectionEntryGroup" targetId="fcc9-3efe-db4e-206d"/>
+            <entryLink import="true" name="Mutation" hidden="false" id="722e-7882-2b96-d8c4" type="selectionEntryGroup" targetId="cc5f-a16a-3abc-1266"/>
+            <entryLink import="true" name="Devious" hidden="false" id="45d9-57f0-6d5f-1fab" type="selectionEntryGroup" targetId="d38f-5d99-694f-98b4"/>
+          </entryLinks>
+        </entryLink>
+      </entryLinks>
+      <infoLinks>
+        <infoLink name="Sprint (Active)" id="1826-521f-12dc-89cc" hidden="false" type="rule" targetId="27c8-91f7-235f-c531"/>
+        <infoLink name="Sure Feet (Active)" id="f9a5-e038-9df4-6bfa" hidden="false" type="rule" targetId="57d4-9f23-820f-5564"/>
+        <infoLink name="Thick Skull (Passive)" id="ad68-5581-b84c-6a0a" hidden="false" type="rule" targetId="d547-b26d-592c-30e1"/>
+        <infoLink name="Unsteady* (Passive)" id="0699-0950-685b-9d14" hidden="false" type="rule" targetId="4a28-69c3-1789-3f44"/>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.be8c-ebf4-021c-1083"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.8de6-19d9-5b42-e667"/>
+        <modifier type="set" value="true" field="hidden" affects="self.entries.3d15-f50c-c6e3-17e9"/>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="69f8-eb37-db8c-47de" id="d6b7-230d-c0f5-ba0c" primary="true" name="Player"/>
+        <categoryLink targetId="5ad4-a76e-f6a6-3438" id="5d68-0805-f4f8-d093" primary="false" name="Bull Centaur"/>
+      </categoryLinks>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <categoryEntries>
+    <categoryEntry name="Hobgoblin Lineman" id="553b-6d18-8ac0-77cd" hidden="false">
+      <constraints>
+        <constraint type="max" value="16" field="selections" scope="roster" shared="true" id="2fe3-e97b-12b1-95c9" includeChildSelections="true"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry name="Sneaky Stabba" id="0969-47b5-9a25-9322" hidden="false">
+      <constraints>
+        <constraint type="max" value="2" field="selections" scope="roster" shared="true" id="cec2-de84-4f77-356c" includeChildSelections="true"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry name="Chaos Dwarf Blocker" id="3ba4-e9d0-1bac-92f7" hidden="false">
+      <constraints>
+        <constraint type="max" value="4" field="selections" scope="roster" shared="true" id="9bd0-27da-2c55-b5b7" includeChildSelections="true"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry name="Flamesmith" id="0e28-f117-7a31-5e27" hidden="false">
+      <constraints>
+        <constraint type="max" value="2" field="selections" scope="roster" shared="true" id="b932-e524-494c-11ab" includeChildSelections="true"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry name="Bull Centaur" id="5ad4-a76e-f6a6-3438" hidden="false">
+      <constraints>
+        <constraint type="max" value="2" field="selections" scope="roster" shared="true" id="7197-1b8b-6910-571c" includeChildSelections="true"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry name="Minotaur" id="3d3b-777b-8c7d-a187" hidden="false">
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="dec4-f9cf-66a8-13dc" includeChildSelections="true"/>
+      </constraints>
+    </categoryEntry>
+  </categoryEntries>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Special Rules" hidden="false" id="687d-e043-1607-818b">
+      <categoryLinks>
+        <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="a7cd-0eb4-c4b2-0b2c" primary="true" name="Team Management"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Favoured of Hashut" hidden="false" id="5eb1-72ba-ec15-7523" type="selectionEntry" targetId="29dc-51bf-a4d4-e460">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="20c2-cf43-30b0-3de5-min" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="20c2-cf43-30b0-3de5-max" includeChildSelections="false"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="2334-8d43-e4eb-0b4f-min" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="2334-8d43-e4eb-0b4f-max" includeChildSelections="true"/>
+      </constraints>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Team League" hidden="false" id="1d2b-d66c-4091-d6e8">
+      <categoryLinks>
+        <categoryLink targetId="9e9f-1d0d-a83d-4cba" id="d744-1812-b5e3-5d69" primary="true" name="Team Management"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Team League" id="2a4b-4f0e-73e5-8bfa" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Chaos Clash" hidden="false" id="4b19-96bb-c0c0-b540" type="selectionEntry" targetId="59e3-4dbf-4f7b-9276">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fd9d-70b8-1ff2-f8f1" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Badlands Brawl" hidden="false" id="fac3-c0e0-6c10-0532" type="selectionEntry" targetId="1eb9-891a-5a20-b694">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fd60-9f88-ce70-69db" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="b66e-72b0-a204-8e11-min" includeChildSelections="true"/>
+            <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b66e-72b0-a204-8e11-max" includeChildSelections="true"/>
+          </constraints>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink import="true" name="Bull Centaur" hidden="false" id="9aa3-c435-e51b-a154" type="selectionEntry" targetId="4d10-f149-c8b7-9b21">
+      <costs>
+        <cost name="TV" typeId="c4da-96df-1abd-13be" value="130000"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Chaos Dwarf Blocker" hidden="false" id="b24d-8140-cf37-9089" type="selectionEntry" targetId="9ac2-cc89-d21f-b1f2">
+      <costs>
+        <cost name="TV" typeId="c4da-96df-1abd-13be" value="70000"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Sneaky Stabba" hidden="false" id="9260-5310-561c-0713" type="selectionEntry" targetId="0d88-2f7d-b8d9-9507">
+      <costs>
+        <cost name="TV" typeId="c4da-96df-1abd-13be" value="60000"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Minotaur" hidden="false" id="27bc-5aa3-99f9-5736" type="selectionEntry" targetId="e104-28ff-6f3d-77c8">
+      <costs>
+        <cost name="TV" typeId="c4da-96df-1abd-13be" value="150000"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Hobgoblin Lineman" hidden="false" id="b26e-c20a-f97c-e8ec" type="selectionEntry" targetId="1b41-182d-9b3c-a0b0">
+      <costs>
+        <cost name="TV" typeId="c4da-96df-1abd-13be" value="40000"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Flamesmith" hidden="false" id="8b23-5a19-8898-2d8f" type="selectionEntry" targetId="082a-05c9-f837-ca5d">
+      <costs>
+        <cost name="TV" typeId="c4da-96df-1abd-13be" value="80000"/>
+      </costs>
+    </entryLink>
+  </entryLinks>
+</catalogue>

--- a/bloodbowl-S3.gst
+++ b/bloodbowl-S3.gst
@@ -906,8 +906,8 @@
         </entryLink>
       </entryLinks>
       <constraints>
-        <constraint type="min" value="1" field="selections" scope="roster" shared="true" id="656f-308c-b966-d713-min" includeChildSelections="true"/>
-        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="656f-308c-b966-d713-max" includeChildSelections="true"/>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="387a-168b-d622-13d6-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="387a-168b-d622-13d6-max" includeChildSelections="false"/>
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -1748,7 +1748,7 @@ If a team has a choice of any alignment, they can choose from any of the followi
     <selectionEntry type="upgrade" import="true" name="Woodland League" hidden="false" id="6c75-8f97-472e-204c">
       <comment>Team Leauge</comment>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="World&apos;s Edge Superleague" hidden="false" id="a8a2-1453-da6f-731c">
+    <selectionEntry type="upgrade" import="true" name="Worlds Edge Superleague" hidden="false" id="a8a2-1453-da6f-731c">
       <comment>Team Leauge</comment>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Brawlin&apos; Brutes" hidden="false" id="0d8a-9c12-8664-38e8">
@@ -1787,6 +1787,12 @@ If a team has a choice of any alignment, they can choose from any of the followi
     <selectionEntry type="upgrade" import="true" name="Favoured of Tzeentch" hidden="false" id="12ee-8bbc-e957-279b"/>
     <selectionEntry type="upgrade" import="true" name="Favoured of Slaanesh" hidden="false" id="a1f9-87ba-0db6-989a"/>
     <selectionEntry type="upgrade" import="true" name="Favoured of Nurgle" hidden="false" id="d66c-3805-c337-bbb6"/>
+    <selectionEntry type="upgrade" import="true" name="Favored of ..." hidden="false" id="7614-610c-c42c-5a78">
+      <infoLinks>
+        <infoLink name="Favoured of ..." id="f76e-423c-4f15-d2dd" hidden="false" type="rule" targetId="84ac-f521-708b-c779"/>
+      </infoLinks>
+      <comment>Team Special Rules</comment>
+    </selectionEntry>
   </sharedSelectionEntries>
   <entryLinks>
     <entryLink import="true" name="Team Re-Rolls" hidden="false" id="18e0-709a-8d63-a381" type="selectionEntry" targetId="9350-0bc7-c2fc-7af5">


### PR DESCRIPTION
Started off with the goal of adding a bunch of teams, but then I encountered the first teams with special rules and I also realized that the team league also matters for roster building, so I went ahead and implemented those.

- Added Special Rules section to team management for the teams that have it (currently just Black Orcs, Chaos Chosen and Chaos Dwarfs)
- Added Team League section to team management and implemented it for the existing team catalogues, apart from humans since I don't know the status of that one (whether it's complete or not or just a testbed)

Resolves #2
Resolves #4
Resolves #5
Resolves #33
Resolves #35
Resolves #38